### PR TITLE
Revamp stylesheets to create name and number

### DIFF
--- a/source/dapsenv/data/guidename.xsl
+++ b/source/dapsenv/data/guidename.xsl
@@ -3,6 +3,10 @@
   Purpose:
     Returns title of book or article
 
+  Parameters:
+    * rootid
+      Applies stylesheet only to part of the document
+
   Author(s):  Thomas Schraitle <toms@opensuse.org>
 
   Copyright:  2016 Thomas Schraitle
@@ -12,25 +16,21 @@
  xmlns:xsl="http://www.w3.org/1999/XSL/Transform"
  xmlns:d="http://docbook.org/ns/docbook">
 
+ <xsl:import href="rootid.xsl"/>
  <xsl:output method="text"/>
 
  <xsl:template match="text()"/>
 
- <xsl:template match="/">
-  <xsl:variable name="db5.set" select="(d:set/d:title | d:set/d:info/d:title)[1]"/>
-  <xsl:variable name="db5.book" select="(d:book/d:title | d:book/d:info/d:title)[1]"/>
-  <xsl:variable name="db5.article" select="(d:article/d:title | d:article/d:info/d:title)[1]"/>
-  <xsl:variable name="db5" select="($db5.set | $db5.book | $db5.article)[1]"/>
-  <xsl:variable name="db4.set" select="(set/title | set/setinfo/title)[1]"/>
-  <xsl:variable name="db4.book" select="(book/title | book/bookinfo/title)[1]"/>
-  <xsl:variable name="db4.article" select="(article/title | article/articleinfo/title)[1]"/>
-  <xsl:variable name="db4" select="($db4.set | $db4.book | $db4.article)[1]"/>
+ <xsl:template match="d:set/d:title | d:set/d:info/d:title |
+                      d:book/d:title | d:book/d:info/d:title |
+                      d:article/d:title | d:article/d:info/d:title">
+  <xsl:value-of select="string(.)"/>
+ </xsl:template>
 
-  <xsl:choose>
-   <xsl:when test="$db5"><xsl:value-of select="normalize-space(string($db5))"/></xsl:when>
-   <xsl:when test="$db4"><xsl:value-of select="normalize-space(string($db4))"/></xsl:when>
-   <xsl:otherwise><xsl:message>ERROR: No title found!</xsl:message></xsl:otherwise>
-  </xsl:choose>
+ <xsl:template match="set/title | set/setinfo/title |
+                      book/title | book/bookinfo/title |
+                      article/title | article/articleinfo/title">
+   <xsl:value-of select="string(.)"/>
  </xsl:template>
 
 </xsl:stylesheet>

--- a/source/dapsenv/data/productname.xsl
+++ b/source/dapsenv/data/productname.xsl
@@ -3,6 +3,10 @@
   Purpose:
     Returns productname of the guide
 
+  Parameters:
+    * rootid
+      Applies stylesheet only to part of the document
+
   Author(s):  Thomas Schraitle <toms@opensuse.org>
 
   Copyright:  2016 Thomas Schraitle
@@ -12,39 +16,21 @@
  xmlns:xsl="http://www.w3.org/1999/XSL/Transform"
  xmlns:d="http://docbook.org/ns/docbook">
 
+ <xsl:import href="rootid.xsl"/>
  <xsl:output method="text"/>
 
  <xsl:template match="text()"/>
 
- <xsl:template match="/">
-  <xsl:variable name="db5.set" select="d:set/d:info/d:productname[1]"/>
-  <xsl:variable name="db5.book" select="d:book/d:info/d:productname[1]"/>
-  <xsl:variable name="db5.article" select="d:article/d:info/d:productname[1]"/>
-  <xsl:variable name="db5">
-   <xsl:choose>
-    <xsl:when test="$db5.set"><xsl:value-of select="string($db5.set)"/></xsl:when>
-    <xsl:when test="$db5.book"><xsl:value-of select="string($db5.book)"/></xsl:when>
-    <xsl:when test="$db5.article"><xsl:value-of select="string($db5.article)"/></xsl:when>
-    <xsl:otherwise/>
-   </xsl:choose>
-  </xsl:variable>
-  <xsl:variable name="db4.set" select="set/bookinfo/productname[1]"/>
-  <xsl:variable name="db4.book" select="book/bookinfo/productname[1]"/>
-  <xsl:variable name="db4.article" select="article/articleinfo/productname[1]"/>
-  <xsl:variable name="db4">
-   <xsl:choose>
-    <xsl:when test="$db4.set"><xsl:value-of select="string($db5.set)"/></xsl:when>
-    <xsl:when test="$db4.book"><xsl:value-of select="string($db5.book)"/></xsl:when>
-    <xsl:when test="$db4.article"><xsl:value-of select="string($db5.article)"/></xsl:when>
-    <xsl:otherwise/>
-   </xsl:choose>
-  </xsl:variable>
+ <xsl:template match="d:set/d:info/d:productname[1] |
+                      d:book/d:info/d:productname[1] |
+                      d:article/d:info/d:productname[1]">
+  <xsl:value-of select="string(.)"/>
+ </xsl:template>
 
-  <xsl:choose>
-   <xsl:when test="$db5"><xsl:value-of select="normalize-space($db5)"/></xsl:when>
-   <xsl:when test="$db4"><xsl:value-of select="normalize-space($db4)"/></xsl:when>
-   <xsl:otherwise><xsl:message>ERROR: No productname found!</xsl:message></xsl:otherwise>
-  </xsl:choose>
+ <xsl:template match="set/setinfo/productname[1] |
+                      book/bookinfo/productname[1] |
+                      article/articleinfo/productname[1]">
+  <xsl:value-of select="string(.)"/>
  </xsl:template>
 
 </xsl:stylesheet>

--- a/source/dapsenv/data/productnumber.xsl
+++ b/source/dapsenv/data/productnumber.xsl
@@ -3,6 +3,10 @@
   Purpose:
     Returns productnumber of the guide
 
+  Parameters:
+    * rootid
+      Applies stylesheet only to part of the document
+
   Author(s):  Thomas Schraitle <toms@opensuse.org>
 
   Copyright:  2016 Thomas Schraitle
@@ -12,25 +16,22 @@
  xmlns:xsl="http://www.w3.org/1999/XSL/Transform"
  xmlns:d="http://docbook.org/ns/docbook">
 
+ <xsl:import href="rootid.xsl"/>
  <xsl:output method="text"/>
 
  <xsl:template match="text()"/>
 
- <xsl:template match="/">
-  <xsl:variable name="db5.set" select="d:set/d:info/d:productnumber[1]"/>
-  <xsl:variable name="db5.book" select="d:book/d:info/d:productnumber[1]"/>
-  <xsl:variable name="db5.article" select="d:article/d:info/d:productnumber[1]"/>
-  <xsl:variable name="db5" select="($db5.set | $db5.book | $db5.article)[1]"/>
-  <xsl:variable name="db4.set" select="set/setinfo/productnumber[1]"/>
-  <xsl:variable name="db4.book" select="book/bookinfo/productnumber[1]"/>
-  <xsl:variable name="db4.article" select="article/articleinfo/productnumber[1]"/>
-  <xsl:variable name="db4" select="($db4.set | $db4.book | $db4.article)[1]"/>
-
-  <xsl:choose>
-   <xsl:when test="$db5"><xsl:value-of select="normalize-space($db5)"/></xsl:when>
-   <xsl:when test="$db4"><xsl:value-of select="normalize-space($db4)"/></xsl:when>
-   <xsl:otherwise><xsl:message>ERROR: No productnumber found!</xsl:message></xsl:otherwise>
-  </xsl:choose>
+ <xsl:template match="d:set/d:info/d:productnumber[1] |
+                      d:book/d:info/d:productnumber[1] |
+                      d:article/d:info/d:productnumber[1]">
+  <xsl:value-of select="string(.)"/>
  </xsl:template>
+
+ <xsl:template match="set/setinfo/productnumber[1] |
+                      book/bookinfo/productnumber[1] |
+                      article/articleinfo/productnumber[1]">
+  <xsl:value-of select="string(.)"/>
+ </xsl:template>
+
 
 </xsl:stylesheet>

--- a/source/dapsenv/data/rootid.xsl
+++ b/source/dapsenv/data/rootid.xsl
@@ -1,0 +1,80 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+   Purpose:
+     Provides basic templates for applying a stylesheet only to fraction
+     of the document
+     
+   Parameters:
+     * rootid
+       Applies stylesheet only to part of the document
+       
+     * rootid.debug (default: 0)
+       Controls some log messages (0=no, 1=yes)
+       
+   Keys:
+     * id (applys to: @id|@xml:id)
+       Creates an index for all elements with IDs
+       
+   Input:
+     DocBook 4/Novdoc document
+     
+   Output:
+     Reduced XML which contains only a fraction of the original document
+     
+   Note:
+     This stylesheet cannot be used as a "standalone" transformatin. It
+     is normally imported and the exported templates are overwritten.
+   
+   Author:    Thomas Schraitle <toms@opensuse.org>
+   Copyright (C) 2012-2015 SUSE Linux GmbH
+   
+-->
+<xsl:stylesheet version="1.0"
+  xmlns:xsl="http://www.w3.org/1999/XSL/Transform">
+
+  <xsl:key name="id" match="*" use="@id|@xml:id"/>
+  <xsl:param name="rootid"/>
+  <!--  -->
+  <xsl:param name="rootid.debug" select="0"/>
+
+  <xsl:template match="/" name="process.rootid.node">
+    <xsl:choose>
+      <xsl:when test="$rootid !=''">
+        <xsl:if test="count(key('id',$rootid)) = 0">
+          <xsl:call-template name="rootid.noelementfound.message"/>
+        </xsl:if>
+        <xsl:call-template name="rootid.debug.message"/>
+        <xsl:call-template name="rootid.process"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:call-template name="normal.process"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:template>
+
+  <xsl:template name="rootid.noelementfound.message">
+    <xsl:message terminate="yes">
+      <xsl:text>ID '</xsl:text>
+      <xsl:value-of select="$rootid"/>
+      <xsl:text>' not found in document.</xsl:text>
+    </xsl:message>
+  </xsl:template>
+
+  <xsl:template name="rootid.debug.message">
+    <xsl:if test="$rootid.debug != 0">
+      <xsl:message>
+        <xsl:text>Using ID </xsl:text>
+        <xsl:value-of select="concat('&quot;', $rootid, '&quot;')"/>
+      </xsl:message>
+    </xsl:if>
+  </xsl:template>
+  
+  <xsl:template name="rootid.process">
+    <xsl:apply-templates select="key('id',$rootid)"/>
+  </xsl:template>
+
+  <xsl:template name="normal.process">
+    <xsl:apply-templates/>
+  </xsl:template>
+  
+</xsl:stylesheet>


### PR DESCRIPTION
- support `rootid` parameter (using `--stringparam rootid <XMLID>`)
- refactore stylesheets to support rootid feature (using the `rootid.xsl` stylesheet)
- use separate templates for DocBook 4 and 5
